### PR TITLE
Fix access type parameter

### DIFF
--- a/lib/oauth-connector.js
+++ b/lib/oauth-connector.js
@@ -36,7 +36,7 @@ class OAuthConnector{
     getAuthorizationUrl(accessType=Enum.AccessType.Online, promptUser=false, state) {
         let url = this.dcConfig.base_domain + internalConfig.auth_path+'?'
                     + `response_type=${encodeURIComponent(this.response_type)}&client_id=${encodeURIComponent(this.clientId)}&redirect_uri=${encodeURIComponent(this.redirectUri)}`
-                    + `&scope=${encodeURIComponent(this._getScopesAsString())}&accessType=${encodeURIComponent(accessType)}`;
+                    + `&scope=${encodeURIComponent(this._getScopesAsString())}&access_type=${encodeURIComponent(accessType)}`;
         if(promptUser) {
             url = url + "&prompt=consent"
         }

--- a/tests/oauth-connector.js
+++ b/tests/oauth-connector.js
@@ -34,7 +34,7 @@ function compareResposne(response, expectedResponse, t){
 test('getAuthorizationUrl', async t => {
     const oAuthConnector = t.context.oAuthConnector;
     let url = oAuthConnector.getAuthorizationUrl(Enum.AccessType.Offline, true, '123');
-    t.deepEqual(url, 'https://accounts.zoho.com/oauth/v2/auth?response_type=code&client_id=test-client-id&redirect_uri=http%3A%2F%2Flocalhost%2Fsample-redirect&scope=scope1%2Cscope2&accessType=offline&prompt=consent&state=123')
+    t.deepEqual(url, 'https://accounts.zoho.com/oauth/v2/auth?response_type=code&client_id=test-client-id&redirect_uri=http%3A%2F%2Flocalhost%2Fsample-redirect&scope=scope1%2Cscope2&access_type=offline&prompt=consent&state=123')
 });
 
 


### PR DESCRIPTION
Hi!

First of all, thank you a lot for this library. It was very useful for my internal integration with Zoho CRM, and I found it more convenient than passport-js. :)

I noticed small issue, where a consumer cannot get a refresh token once they are authenticated. This happens due to the invalid access type parameter added to the authentication URL. It should be `access_type` according to Zoho [documentation][docs] (see the "Parameters" section for details). Now the `accessType` parameter is used, which is ignored by Zoho. 

Please let me know if the `accessType` parameter is used intentionally.

[docs]: https://www.zoho.com/crm/developer/docs/api/v2/auth-request.html