### PR TITLE
Remove unused console.log

### DIFF
--- a/lib/oauth-connector.js
+++ b/lib/oauth-connector.js
@@ -82,7 +82,6 @@ class OAuthConnector{
     async getAccessTokenAndRefreshToken(code, state){
         try{
             let url = this.getAccessTokenUrl(code, state);
-            console.log(url)
             let tokenResponse = (await this.axios.post(url)).data;
             this._convertExpiresIn(tokenResponse);
             return tokenResponse;


### PR DESCRIPTION
A small patch that removes unused console.log output.

Feel free to close this PR, if you want to keep this output. I'll utilise my fork then.